### PR TITLE
Fix first-file-lost-content

### DIFF
--- a/create_project_markdown.py
+++ b/create_project_markdown.py
@@ -137,6 +137,8 @@ class MarkdownWriter:
 
         # If we created multiple chunks, create an index
         if len(self.chunks) > 1:
+            # Create a new index file with a different name to avoid overwriting the first chunk
+            index_filename = f"{os.path.splitext(self.base_filename)[0]}_index{os.path.splitext(self.base_filename)[1]}"
             index_content = ["# Project Structure Index\n\n"]
             total_size = 0
 
@@ -153,10 +155,10 @@ class MarkdownWriter:
 
             index_content.append(f"\nTotal size: {total_size / 1024:.2f}KB")
 
-            # Write the index file
-            with open(self.base_filename, 'w', encoding='utf-8') as f:
+            # Write the index to a separate file
+            with open(index_filename, 'w', encoding='utf-8') as f:
                 f.write('\n'.join(index_content))
-            logging.info(f"Created index file with {len(self.chunks)} chunks, total size: {total_size / 1024:.2f}KB")
+            logging.info(f"Created index file {index_filename} with {len(self.chunks)} chunks, total size: {total_size / 1024:.2f}KB")
 
 
 def load_gitignore(project_path: str) -> PathSpec:


### PR DESCRIPTION
This pull request includes changes to the `create_project_markdown.py` file to improve how the index file is handled when multiple chunks are created. The main changes involve creating a new index file with a different name to avoid overwriting the first chunk and updating the logging information accordingly.

Changes to index file handling:

* [`create_project_markdown.py`](diffhunk://#diff-4802c86df2a848d7a03f99faf7b37c5e7e407c091a34cac035da1de913d600e7R140-R141): Added logic to create a new index file with a different name to avoid overwriting the first chunk.
* [`create_project_markdown.py`](diffhunk://#diff-4802c86df2a848d7a03f99faf7b37c5e7e407c091a34cac035da1de913d600e7L156-R161): Updated the code to write the index to the newly created file and adjusted the logging information to reflect the new filename.